### PR TITLE
Fix link to the Contributor covenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ or
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/elpassion/grape-cli. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/elpassion/grape-cli. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](CODE_OF_CONDUCT.md) code of conduct.
 
 
 ## License


### PR DESCRIPTION
Hi,
There's a `CODE_OF_CONDUCT.md` on the root of the project which I believe is the intended file that this link should be pointing to. Don't know if it is but makes a lot of sense to me.

Attempt's to fix issue #31