### PR TITLE
Remove major version lock for bundler

### DIFF
--- a/grape-cli.gemspec
+++ b/grape-cli.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'thor', '~> 0.19'
-  spec.add_dependency 'bundler', '~> 1.10'
+  spec.add_dependency 'bundler'
   spec.add_dependency 'racksh'
 
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi

It seems that the project does not require any deprecated or broken feature from bundler V1, and it works just fine with bundler V2